### PR TITLE
zipruby から rubyzip へ

### DIFF
--- a/lib/zip_code_jp/export.rb
+++ b/lib/zip_code_jp/export.rb
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-require 'zipruby'
+require 'zip'
 require 'json'
 require 'open-uri'
 require 'csv'
@@ -27,9 +27,9 @@ module ZipCodeJp
     def self.zip_codes
       zip_codes = {}
       prefecture_codes = YAML.load(File.open("#{ZipCodeJp::DATA_DIR}/prefecture_code.yml"))
-      Zip::Archive.open(open(ZIP_URL).path) do |archives|
+      Zip::File.open(open(ZIP_URL).path) do |archives|
         archives.each do |a|
-          CSV.parse(a.read) do |row|
+          CSV.parse(a.get_input_stream.read) do |row|
             h = to_hash(row)
             h[:prefecture_code] = prefecture_codes.invert[h[:prefecture]]
             first_prefix  = h[:zip_code].slice(0,3)

--- a/lib/zip_code_jp/version.rb
+++ b/lib/zip_code_jp/version.rb
@@ -1,3 +1,3 @@
 module ZipCodeJp
-  VERSION = '0.0.3'
+  VERSION = '0.0.4'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 require 'rubygems'
+require 'pry'
 require 'zip_code_jp'

--- a/spec/zip_code_jp_spec.rb
+++ b/spec/zip_code_jp_spec.rb
@@ -2,7 +2,6 @@
 require File.dirname(__FILE__) + '/spec_helper'
 
 describe ZipCodeJp do
-
   describe 'If you want to search from the zip code.' do
     it 'zip code exists.' do
       address = ZipCodeJp.find '102-0072'
@@ -32,6 +31,12 @@ describe ZipCodeJp do
     it 'zip code does not exists.' do
       address = ZipCodeJp.find '000-0000'
       expect(address).to eq(false)
+    end
+  end
+
+  describe 'ZipCodeJp.export_json' do
+    it 'does NOT raise any errors' do
+      expect { ZipCodeJp.export_json }.not_to raise_error
     end
   end
 end

--- a/zip_code_jp.gemspec
+++ b/zip_code_jp.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "pry"
-  spec.add_dependency "zipruby"
+  spec.add_dependency "rubyzip"
 end


### PR DESCRIPTION
現状、最新の郵便番号情報を取得する際に [zipruby](https://rubygems.org/gems/zipruby/) を利用しています。

が、
- zipruby は最終更新が 2010 年とメンテナンスがされていない
- 多くの gem が rubyzip を使用している
- zipruby と rubyzip とで `::Zip` 名前空間の衝突が発生しうる
- （↑ の現象が、進行中のプロジェクトで発生して困った）

ので、zipruby の代わりとして [rubyzip/rubyzip](https://github.com/rubyzip/rubyzip) を利用するように修正しました。

参考: [Rename Zip module to RubyZip · Issue #132 · rubyzip/rubyzip](https://github.com/rubyzip/rubyzip/issues/132)
