### PR TITLE
change zip url to official web site

### DIFF
--- a/lib/zip_code_jp/export.rb
+++ b/lib/zip_code_jp/export.rb
@@ -8,7 +8,7 @@ require 'yaml'
 
 module ZipCodeJp
   class Export
-    ZIP_URL  = 'http://zipcloud.ibsnet.co.jp/zipcodedata/download?di=1372407257348'
+    ZIP_URL  = 'http://www.post.japanpost.jp/zipcode/dl/oogaki/zip/ken_all.zip'
 
     private
     def self.to_hash(row)


### PR DESCRIPTION
ZIP_URLが古いダウンロードファイルのみしか聞いていないため、公式から最新のZipをダウンロードできるように変数のURLを変更
