### PR TITLE
htmlパースライブラリをnokogiriからogaへ

### DIFF
--- a/lib/zip_code_jp/export.rb
+++ b/lib/zip_code_jp/export.rb
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 require 'zip'
 require 'json'
-require 'nokogiri'
+require 'oga'
 require 'open-uri'
 require 'csv'
 require 'nkf'
@@ -26,8 +26,8 @@ module ZipCodeJp
 
     private
     def self.zip_url
-      html = Nokogiri::HTML(open(ZIP_URL_DOMAIN))
-      url = html.css('[href^="/zipcodedata/download"]').last.attributes['href']
+      html =  Oga.parse_html(open(ZIP_URL_DOMAIN))
+      url = html.css('[href^="/zipcodedata/download"]').last.get('href')
 
       "#{ZIP_URL_DOMAIN}#{url}"
     end

--- a/lib/zip_code_jp/export.rb
+++ b/lib/zip_code_jp/export.rb
@@ -26,7 +26,7 @@ module ZipCodeJp
 
     private
     def self.zip_url
-      html =  Oga.parse_html(open(ZIP_URL_DOMAIN))
+      html = Oga.parse_html(open(ZIP_URL_DOMAIN))
       url = html.css('[href^="/zipcodedata/download"]').last.get('href')
 
       "#{ZIP_URL_DOMAIN}#{url}"

--- a/zip_code_jp.gemspec
+++ b/zip_code_jp.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "pry"
   spec.add_dependency "rubyzip"
-  spec.add_dependency "nokogiri"
+  spec.add_dependency "oga"
 end


### PR DESCRIPTION
nokogiriは別途 `libxml` 等のライブラリのインストールが必要など、導入の障壁になるのでogaに変えてみました :smile: 
https://github.com/YorickPeterse/oga

よろしくお願いします！
